### PR TITLE
3 userstory

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -12,12 +12,20 @@ class BulkDiscountsController < ApplicationController
 
   def new
     @merchant = Merchant.find(params[:merchant_id])
-    @discount = @merchant.bulk_discounts.new
+    @bulk_discount = @merchant.bulk_discounts.new
   end
 
   def create
     @merchant = Merchant.find(params[:merchant_id])
-    @discount = @merchant.bulk_discounts.create(discount_params)
+    @bulk_discount = @merchant.bulk_discounts.create(discount_params)
+    redirect_to merchant_bulk_discounts_path(@merchant)
+  end
+
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+    @bulk_discount.destroy
+
     redirect_to merchant_bulk_discounts_path(@merchant)
   end
 

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -8,6 +8,7 @@
     <p>Discount ID: <%= link_to discount.id, merchant_bulk_discount_path(@merchant, discount) %></p>
     <p>Discount: <%= discount.percent_discount %>%</p>
     <p>Quantity Threshold: <%= discount.quantity_threshold %></p>
+    <%= button_to 'Delete Discount', merchant_bulk_discount_path(@merchant, discount), method: :delete %>
     <p>-------------------------------------------</p>
   </div>
 <% end %>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [@merchant, @discount], data: {turbo: false} do |form| %>
+<%= form_with model: [@merchant, @bulk_discount], data: {turbo: false} do |form| %>
   <%= form.label :percent_discount, "Percent Discount" %>
   <%= form.number_field :percent_discount, min: 0, max: 100 %>
 <br />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create]
+    resources :bulk_discounts
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -102,4 +102,17 @@ describe "merchant bulk_discounts index" do
       expect(page).to have_content("Discount: 30")
     end
   end
+
+  it "has a link to delete next to each bulk discount" do
+    within "##{@discount_1.id}" do
+      expect(page).to have_link("Delete Discount")
+      click_link "Delete Discount"
+    end
+    expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+
+    within "#Discounts" do
+      expect(page).to_not have_content("Quantity Threshold: 5")
+      expect(page).to_not have_content("Discount: 10")
+    end
+  end
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -105,8 +105,8 @@ describe "merchant bulk_discounts index" do
 
   it "has a link to delete next to each bulk discount" do
     within "##{@discount_1.id}" do
-      expect(page).to have_link("Delete Discount")
-      click_link "Delete Discount"
+      expect(page).to have_button("Delete Discount")
+      click_button "Delete Discount"
     end
     expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
 


### PR DESCRIPTION
3: Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a button to delete it
When I click this button
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed