### PR TITLE
5 userstory

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -17,7 +17,7 @@ class BulkDiscountsController < ApplicationController
 
   def create
     @merchant = Merchant.find(params[:merchant_id])
-    @bulk_discount = @merchant.bulk_discounts.create(discount_params)
+    @bulk_discount = @merchant.bulk_discounts.create(bulk_discount_params)
     redirect_to merchant_bulk_discounts_path(@merchant)
   end
 
@@ -29,8 +29,23 @@ class BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(@merchant)
   end
 
+  def edit
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+  end
+
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+
+    @bulk_discount.update(bulk_discount_params)
+    flash.notice = "Discount update successful"
+    redirect_to merchant_bulk_discount_path(@merchant, @bulk_discount)
+  end
+  
+
   private
-  def discount_params
+  def bulk_discount_params
     params.require(:bulk_discount).permit(:percent_discount, :quantity_threshold)
   end
 

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: [@merchant, @bulk_discount], data: {turbo: false} do |form| %>
+  <%= form.label :percent_discount, "Percent Discount" %>
+  <%= form.number_field :percent_discount, min: 0, max: 100 %>
+<br />
+  <%= form.label :quantity_threshold, "Quantity Threshold" %>
+  <%= form.number_field :quantity_threshold, min: 1 %>
+<br />
+  <%= form.submit %>
+<% end %>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -3,3 +3,5 @@
 <h1>Discount ID: <%=@bulk_discount.id %></h1>
     <p>Discount: <%= @bulk_discount.percent_discount %>%</p>
     <p>Quantity Threshold: <%= @bulk_discount.quantity_threshold %></p>
+<br />
+<%= link_to 'Edit Discount', edit_merchant_bulk_discount_path(@merchant, @bulk_discount) %>

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -4,12 +4,12 @@ describe "Merchant Bulk Discount Show" do
   before :each do
     @m1 = Merchant.create!(name: "Merchant 1")
     @discount = @m1.bulk_discounts.create!(quantity_threshold: 100, percent_discount: 50)
-    visit edit_merchant_bulk_discount_path(@m1)
+    visit edit_merchant_bulk_discount_path(@m1, @discount)
   end
 
   it "should have a form that redirects back to merchant bulk discount show with a flash message" do
-    fill_in "discount[quantity_threshold]", with: 120
-    fill_in "discount[percent_discount]", with: 45
+    fill_in "Quantity Threshold", with: 120
+    fill_in "Percent Discount", with: 45
     click_button
 
     expect(current_path).to eq(merchant_bulk_discount_path(@m1, @discount))

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+describe "Merchant Bulk Discount Show" do
+  before :each do
+    @m1 = Merchant.create!(name: "Merchant 1")
+    @discount = @m1.bulk_discounts.create!(quantity_threshold: 100, percent_discount: 50)
+    visit edit_merchant_bulk_discount_path(@m1)
+  end
+
+  it "should have a form that redirects back to merchant bulk discount show with a flash message" do
+    fill_in "discount[quantity_threshold]", with: 120
+    fill_in "discount[percent_discount]", with: 45
+    click_button
+
+    expect(current_path).to eq(merchant_bulk_discount_path(@m1, @discount))
+    expect(page).to have_content("Quantity Threshold: 120")
+    expect(page).to have_content("Discount: 45%")
+    expect(page).to have_content("Discount update successful")
+  end
+end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -69,4 +69,12 @@ describe "merchant bulk_discount show" do
     expect(page).to_not have_content("Discount: #{@discount_2.percent_discount}")
     expect(page).to_not have_content("Quantity Threshold: #{@discount_2.quantity_threshold}")
   end
+
+  it "should have a link to Update discount" do
+    expect(page).to have_link("Update Discount")
+
+    click_link "Update Merchant"
+
+    expect(current_path).to eq(edit_admin_merchant_path(@m1))
+  end
 end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -70,11 +70,11 @@ describe "merchant bulk_discount show" do
     expect(page).to_not have_content("Quantity Threshold: #{@discount_2.quantity_threshold}")
   end
 
-  it "should have a link to Update discount" do
-    expect(page).to have_link("Update Discount")
+  it "should have a link to Edit discount" do
+    expect(page).to have_link("Edit Discount")
 
-    click_link "Update Merchant"
+    click_link "Edit Discount"
 
-    expect(current_path).to eq(edit_admin_merchant_path(@m1))
+    expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @discount_1))
   end
 end


### PR DESCRIPTION
5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated