### PR TITLE
9 userstory

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -3,6 +3,7 @@ class BulkDiscountsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
     @bulk_discounts = @merchant.bulk_discounts
+    @upcoming_holidays = HolidaysService.upcoming_holidays
   end
 
   def show

--- a/app/services/holidays_service.rb
+++ b/app/services/holidays_service.rb
@@ -3,6 +3,7 @@ class HolidaysService
     url = 'https://date.nager.at/Api/v3/NextPublicHolidays/US'
     response = Faraday.get(url)
     parsed_holidays = JSON.parse(response.body)
-    parsed_holidays.map { |holiday_data| Holiday.new(holiday_data)}
+    holidays = parsed_holidays.map { |holiday_data| Holiday.new(holiday_data)}
+    holidays.first(3)
   end
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,7 +1,12 @@
 <%= render partial: "shared/nav" %>
+<div id="Holidays">
+<h2>Upcoming Holidays</h2>
+<% @upcoming_holidays.each do |holiday|%>
+ <p><%= holiday.name %> on <%= holiday.date %> </p>
+<% end %>
+</div>
 
-<h1><%= @merchant.name %>'s Discounts </h2>
-
+<h3><%= @merchant.name %>'s Discounts </h3>
 <div id="Discounts">
 <% @bulk_discounts.each do |discount| %>
   <div id="<%= discount.id %>">

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -62,6 +62,7 @@ describe "merchant bulk_discounts index" do
   end
 
   it "can see all bulk discount ids and attributes that are associated with the merchant" do
+    save_and_open_page
     expect(page).to have_content(@discount_1.id)
     expect(page).to have_content(@discount_1.percent_discount)
     expect(page).to have_content(@discount_1.quantity_threshold)

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -62,7 +62,6 @@ describe "merchant bulk_discounts index" do
   end
 
   it "can see all bulk discount ids and attributes that are associated with the merchant" do
-    save_and_open_page
     expect(page).to have_content(@discount_1.id)
     expect(page).to have_content(@discount_1.percent_discount)
     expect(page).to have_content(@discount_1.quantity_threshold)
@@ -114,6 +113,18 @@ describe "merchant bulk_discounts index" do
     within "#Discounts" do
       expect(page).to_not have_content("Quantity Threshold: 5")
       expect(page).to_not have_content("Discount: 10")
+    end
+  end
+
+  it "displays the next three upcoming US holidays" do
+    upcoming_holidays = HolidaysService.upcoming_holidays
+    within "#Holidays" do
+      expect(page).to have_content(upcoming_holidays[0].name)
+      expect(page).to have_content(upcoming_holidays[0].date)
+      expect(page).to have_content(upcoming_holidays[1].name)
+      expect(page).to have_content(upcoming_holidays[1].date)
+      expect(page).to have_content(upcoming_holidays[2].name)
+      expect(page).to have_content(upcoming_holidays[2].date)
     end
   end
 end


### PR DESCRIPTION
9: Holidays API

As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)