### PR TITLE
6 userstory

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -69,4 +69,25 @@ class Merchant < ApplicationRecord
                  .where("invoice_items.invoice_id = ?", invoice_id)
                  .sum("invoice_items.quantity * invoice_items.unit_price")
   end
+
+  def discounted_revenue_for_invoice(invoice_id)
+    invoice_items = self.invoice_items.where("invoice_items.invoice_id = ?", invoice_id)
+    discounted_revenue = 0
+  
+    invoice_items.each do |ii|
+      applicable_discount = ii.item.merchant.bulk_discounts
+                               .where("bulk_discounts.quantity_threshold <= ?", ii.quantity)
+                               .order(percent_discount: :desc)
+                               .first
+                               
+      if applicable_discount
+        discounted_price = ii.unit_price * (1 - applicable_discount.percent_discount/100.0)
+        discounted_revenue += discounted_price * ii.quantity
+      else
+        discounted_revenue += ii.unit_price * ii.quantity
+      end
+    end
+  
+    discounted_revenue
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -62,4 +62,11 @@ class Merchant < ApplicationRecord
   def disabled_items
     items.where(status: 0)
   end
+
+  def revenue_for_invoice(invoice_id)
+    invoice_items.joins(:item)
+                 .where("items.merchant_id = ?", self.id)
+                 .where("invoice_items.invoice_id = ?", invoice_id)
+                 .sum("invoice_items.quantity * invoice_items.unit_price")
+  end
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -48,4 +48,10 @@
     </tbody>
   </table>
 
+  <div id="total_revenue">
+  <strong>Total revenue: </strong><%= @merchant.revenue_for_invoice(@invoice) %>
+  <strong>Total revenue after discounts: </strong><%= @merchant.discounted_revenue_for_invoice(@invoice) %>
+  </div>
+  <br>
+
 </body>

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "invoices show" do
 
     visit merchant_invoice_path(@merchant1, @invoice_1)
 
-    within "#Total_revenue" do
+    within "#total_revenue" do
       expect(page).to have_content(@merchant1.revenue_for_invoice(@invoice_1))
       expect(page).to have_content(@merchant1.discounted_revenue_for_invoice(@invoice_1))
     end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -100,4 +100,20 @@ RSpec.describe "invoices show" do
     end
   end
 
+  it "shows total revenue before and after discounts applied for the merchant from given invoice" do
+    @discount_1 = BulkDiscount.create!(quantity_threshold: 5, percent_discount: 5, merchant: @merchant1)
+    @discount_2 = BulkDiscount.create!(quantity_threshold: 7, percent_discount: 10,merchant: @merchant1)
+    @discount_3 = BulkDiscount.create!(quantity_threshold: 10, percent_discount: 15,merchant: @merchant1)
+    @discount_4 = BulkDiscount.create!(quantity_threshold: 12, percent_discount: 17,merchant: @merchant1)
+    @discount_5 = BulkDiscount.create!(quantity_threshold: 15, percent_discount: 20,merchant: @merchant1)
+    @discount_6 = BulkDiscount.create!(quantity_threshold: 20, percent_discount: 25,merchant: @merchant2)
+    @ii_12 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1, created_at: "2012-04-04 14:54:09")
+
+    visit merchant_invoice_path(@merchant1, @invoice_1)
+
+    within "#Total_revenue" do
+      expect(page).to have_content(@merchant1.revenue_for_invoice(@invoice_1))
+      expect(page).to have_content(@merchant1.discounted_revenue_for_invoice(@invoice_1))
+    end
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -182,7 +182,7 @@ describe Merchant do
     end
 
     it "discounted_revenue_for_invoice(invoice)" do
-      expect(@merchant1.discounted_revenue_for_invoice(@invoice_1)).to eq(9)
+      expect(@merchant1.discounted_revenue_for_invoice(@invoice_1)).to eq(81)
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -129,7 +129,7 @@ describe Merchant do
       @ii_8 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_8.id, quantity: 1, unit_price: 5, status: 1, created_at: "2012-04-03 14:54:09")
       @ii_9 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1, created_at: "2012-04-04 14:54:09")
       @ii_10 = InvoiceItem.create!(invoice_id: @invoice_8.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1, created_at: "2012-04-04 14:54:09")
-      @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1, created_at: "2012-04-04 14:54:09")
+      
 
       @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
       @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_2.id)
@@ -171,6 +171,7 @@ describe Merchant do
     end
 
     it "revenue_for_invoice(invoice)" do
+      @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1, created_at: "2012-04-04 14:54:09")
       expect(@merchant1.revenue_for_invoice(@invoice_1)).to eq(90)
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -129,6 +129,7 @@ describe Merchant do
       @ii_8 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_8.id, quantity: 1, unit_price: 5, status: 1, created_at: "2012-04-03 14:54:09")
       @ii_9 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1, created_at: "2012-04-04 14:54:09")
       @ii_10 = InvoiceItem.create!(invoice_id: @invoice_8.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1, created_at: "2012-04-04 14:54:09")
+      @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1, created_at: "2012-04-04 14:54:09")
 
       @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
       @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_2.id)
@@ -167,6 +168,10 @@ describe Merchant do
     it "disabled_items" do 
       expect(@merchant1.disabled_items).to eq([@item_2, @item_3, @item_4, @item_7, @item_8])
       expect(@merchant2.disabled_items).to eq([@item_5, @item_6])
+    end
+
+    it "revenue_for_invoice(invoice)" do
+      expect(@merchant1.revenue_for_invoice(@invoice_1)).to eq(90)
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -140,6 +140,12 @@ describe Merchant do
       @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_7.id)
       @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_8.id)
 
+      @discount_1 = BulkDiscount.create!(quantity_threshold: 5, percent_discount: 5, merchant: @merchant1)
+      @discount_2 = BulkDiscount.create!(quantity_threshold: 7, percent_discount: 10,merchant: @merchant1)
+      @discount_3 = BulkDiscount.create!(quantity_threshold: 10, percent_discount: 15,merchant: @merchant1)
+      @discount_4 = BulkDiscount.create!(quantity_threshold: 12, percent_discount: 17,merchant: @merchant1)
+      @discount_5 = BulkDiscount.create!(quantity_threshold: 15, percent_discount: 20,merchant: @merchant1)
+      @discount_6 = BulkDiscount.create!(quantity_threshold: 20, percent_discount: 25,merchant: @merchant2)
     end
     it "can list items ready to ship" do
       expect(@merchant1.ordered_items_to_ship).to eq([@item_1, @item_1, @item_3, @item_4, @item_7, @item_8, @item_4, @item_4])
@@ -173,6 +179,10 @@ describe Merchant do
     it "revenue_for_invoice(invoice)" do
       @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1, created_at: "2012-04-04 14:54:09")
       expect(@merchant1.revenue_for_invoice(@invoice_1)).to eq(90)
+    end
+
+    it "discounted_revenue_for_invoice(invoice)" do
+      expect(@merchant1.discounted_revenue_for_invoice(@invoice_1)).to eq(9)
     end
   end
 end


### PR DESCRIPTION
6: Merchant Invoice Show Page: Total Revenue and Discounted Revenue

As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation