### PR TITLE
7 userstory

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -91,5 +91,10 @@ class Merchant < ApplicationRecord
     discounted_revenue
   end
 
-
+  def applicable_discount_by_item(invoice_item)
+    bulk_discounts
+                .where("bulk_discounts.quantity_threshold <= ?", invoice_item.quantity)
+                .order(percent_discount: :desc)
+                .first
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -91,7 +91,7 @@ class Merchant < ApplicationRecord
     discounted_revenue
   end
 
-  def applicable_discount_by_item(invoice_item)
+  def applicable_discount(invoice_item)
     bulk_discounts
                 .where("bulk_discounts.quantity_threshold <= ?", invoice_item.quantity)
                 .order(percent_discount: :desc)

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -90,4 +90,6 @@ class Merchant < ApplicationRecord
   
     discounted_revenue
   end
+
+
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -26,6 +26,7 @@
         <th class="th1">Quantity</th>
         <th class="th1">Unit Price</th>
         <th class="th1">Status</th>
+        <th class="th1">Applied Discount</th>
       </tr>
     </thead>
 
@@ -42,15 +43,23 @@
                 <%= f.submit 'Update Invoice' %>
               <% end %>
               </td>
+              
+            <% if @merchant.applicable_discount(i) %>
+            <td style="text-align:center">
+              <% discount = @merchant.applicable_discount(i) %>
+              <%= link_to discount.id, merchant_bulk_discount_path(@merchant, discount.id) %>
+            </td>
+            <% else %>
+            <% end %>
           </tr>
         </section>
       <% end %>
     </tbody>
   </table>
-
+  <br />
   <div id="total_revenue">
-  <strong>Total revenue: </strong><%= @merchant.revenue_for_invoice(@invoice) %>
-  <strong>Total revenue after discounts: </strong><%= @merchant.discounted_revenue_for_invoice(@invoice) %>
+  <strong>Total revenue: </strong>$<%= @merchant.revenue_for_invoice(@invoice) %> <br />
+  <strong>Total revenue after discounts: </strong>$<%= @merchant.discounted_revenue_for_invoice(@invoice) %>
   </div>
   <br>
 

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -116,4 +116,12 @@ RSpec.describe "invoices show" do
       expect(page).to have_content(@merchant1.discounted_revenue_for_invoice(@invoice_1))
     end
   end
+
+  it "has a link to the bulk discount that was applied next to each invoice item" do
+    expect(page).to have_link("#{@discount_1.id}")
+
+    click_link "#{@discount_1.id}"
+
+    expect(current_path).to eq(merchant_bulk_discount_path(@merchant1, @discount_1))
+  end
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -118,10 +118,14 @@ RSpec.describe "invoices show" do
   end
 
   it "has a link to the bulk discount that was applied next to each invoice item" do
-    expect(page).to have_link("#{@discount_1.id}")
+    @discount_1 = BulkDiscount.create!(quantity_threshold: 5, percent_discount: 5, merchant: @merchant1)
+    @discount_2 = BulkDiscount.create!(quantity_threshold: 7, percent_discount: 10,merchant: @merchant1)
+    @discount_3 = BulkDiscount.create!(quantity_threshold: 10, percent_discount: 15,merchant: @merchant1)
 
-    click_link "#{@discount_1.id}"
+    visit merchant_invoice_path(@merchant1, @invoice_1)
+    expect(page).to have_link("#{@discount_2.id}")
+    click_link "#{@discount_2.id}"
 
-    expect(current_path).to eq(merchant_bulk_discount_path(@merchant1, @discount_1))
+    expect(current_path).to eq(merchant_bulk_discount_path(@merchant1, @discount_2))
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -185,8 +185,8 @@ describe Merchant do
       expect(@merchant1.discounted_revenue_for_invoice(@invoice_1)).to eq(81)
     end
 
-    it "applicable_discount_by_item(invoice_item)" do
-      expect(@merchant1.applicable_discount_by_item(@ii_1)).to eq(@discount_2)
+    it "applicable_discount(invoice_item)" do
+      expect(@merchant1.applicable_discount(@ii_1)).to eq(@discount_2)
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -184,5 +184,9 @@ describe Merchant do
     it "discounted_revenue_for_invoice(invoice)" do
       expect(@merchant1.discounted_revenue_for_invoice(@invoice_1)).to eq(81)
     end
+
+    it "applicable_discount_by_item(invoice_item)" do
+      expect(@merchant1.applicable_discount_by_item(@ii_1)).to eq(@discount_2)
+    end
   end
 end


### PR DESCRIPTION
7: Merchant Invoice Show Page: Link to applied discounts

As a merchant
When I visit my merchant invoice show page
Next to each invoice item I see a link to the show page for the bulk discount that was applied (if any)